### PR TITLE
Fix specs for crystal 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -6,3 +6,5 @@ description: |
   Syntax Highlight Library for Crystal
 
 license: MIT
+
+crystal: 1.0.0

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -11,7 +11,7 @@ class SpecFormatter < Noir::Formatter
     @out = IO::Memory.new
   end
 
-  def format(token, value)
+  def format(token, value): Nil
     [token, value].inspect @out
     @out.puts
   end


### PR DESCRIPTION
Specs don't run with Crystal throwing this error:

```
➜  noir git:(master) ✗ crystal spec
Showing last frame. Use --error-trace for full trace.

In spec/spec_helper.cr:14:7

 14 | def format(token, value)
          ^-----
Error: this method overrides Noir::Formatter#format(token : Token | ::Nil, value : String) which has an explicit return type of Nil.

Please add an explicit return type (Nil or a subtype of it) to this method as well.
```

Adding the return type to `format` as asked by the compiler fixes the problem.