### PR TITLE
Fix comment detection in python

### DIFF
--- a/spec/lexers/python/fixtures/fizzbuzz.in
+++ b/spec/lexers/python/fixtures/fizzbuzz.in
@@ -1,3 +1,4 @@
+# fizzbuzz.py
 from collections import defaultdict
 
 fizz, buzz = defaultdict(lambda: ''), defaultdict(lambda: '')

--- a/spec/lexers/python/fixtures/fizzbuzz.out
+++ b/spec/lexers/python/fixtures/fizzbuzz.out
@@ -1,3 +1,5 @@
+[#<Token Comment>, "# fizzbuzz.py"]
+[#<Token Text>, "\n"]
 [#<Token Keyword::Namespace>, "from"]
 [#<Token Text>, " "]
 [#<Token Name::Namespace>, "collections"]

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -11,7 +11,7 @@ class SpecFormatter < Noir::Formatter
     @out = IO::Memory.new
   end
 
-  def format(token, value)
+  def format(token, value): Nil
     [token, value].inspect @out
     @out.puts
   end

--- a/src/noir/lexers/python.cr
+++ b/src/noir/lexers/python.cr
@@ -56,7 +56,7 @@ class Noir::Lexers::Python < Noir::Lexer
     rule /^(:)(\s*)([ru]{,2}""".*?""")/mi, &.groups Punctuation, Text, Str::Doc
 
     rule /[^\S\n]+/, Text
-    rule /#.*$/, Comment
+    rule /#[^\n\r].*/, Comment
     rule /[\[\]{}:(),;]/, Punctuation
     rule /\\\n/, Text
     rule /\\/, Text


### PR DESCRIPTION
Due to the difference between Ruby and Crystal regarding regexp handling, Python comments where not properly detected.

With Crystal, `/#.*$/` will match multiple lines and will not match at the first end of the line or \n\r like in Ruby. Specifying that we want to match everything on the line until the next newline or carriage return works as expected `/[^\n\r].*/`